### PR TITLE
Optimize jquery.event.drop locate function

### DIFF
--- a/event.drop/jquery.event.drop.js
+++ b/event.drop/jquery.event.drop.js
@@ -159,19 +159,11 @@ drop = $.event.special.drop = {
 	// returns the location positions of an element
 	locate: function( elem, index ){ 
 		var data = $.data( elem, drop.datakey ),
-		$elem = $( elem ), 
-		posi = $elem.offset() || {}, 
-		height = $elem.outerHeight(), 
-		width = $elem.outerWidth(),
-		location = { 
-			elem: elem, 
-			width: width, 
-			height: height,
-			top: posi.top, 
-			left: posi.left, 
-			right: posi.left + width, 
-			bottom: posi.top + height
-		};
+		location = $.extend({elem:elem}, elem.getBoundingClientRect());
+		if (!location.width) {
+			location.width = location.right - location.left;
+			location.height = location.bottom - location.top;
+		}
 		// drag elements might not have dropdata
 		if ( data ){
 			data.location = location;


### PR DESCRIPTION
Instead of using the jQuery methods position, outerWidth, and outerHeight to compute the dimensions of a DOM element, use the native getBoundingClientRect function instead. Simplifies the code a bit and should also speed up the critical "locate" function a bit (http://jsperf.com/getboundingclientrect-vs-jquery). Its been around long enough (https://developer.mozilla.org/en/DOM/element.getBoundingClientRect) so it shouldn't cause any cross-platform weirdness either.
