### PR TITLE
event.drag: cope with undefined/null events in $.event.dispatch wrapper

### DIFF
--- a/event.drag/jquery.event.drag.js
+++ b/event.drag/jquery.event.drag.js
@@ -367,7 +367,7 @@ drag.callback.prototype = {
 // patch $.event.$dispatch to allow suppressing clicks
 var $dispatch = $event.dispatch;
 $event.dispatch = function( event ){
-	if ( $.data( this, "suppress."+ event.type ) - new Date().getTime() > 0 ){
+	if ( event && event.type && $.data( this, "suppress."+ event.type ) - new Date().getTime() > 0 ){
 		$.removeData( this, "suppress."+ event.type );
 		return;
 	}


### PR DESCRIPTION
IE seems to enjoy sending undefined event objects on load events
just to make everyone's life difficult.
